### PR TITLE
Enhance markdown2pdf styling and highlights

### DIFF
--- a/asistente-asignatura/scriptsAuxiliares/conversores/markdown2Pdf/README.md
+++ b/asistente-asignatura/scriptsAuxiliares/conversores/markdown2Pdf/README.md
@@ -34,7 +34,7 @@ markdown2Pdf/
 - **Conversión recursiva** de todos los Markdown en un directorio y subdirectorios.
 - **Modo archivo único** para convertir solo un `.md`.
 - **Renderizado profesional** con tipografía moderna, encabezados y pies de página automáticos.
-- **Resaltado de sintaxis** basado en *Pygments* para bloques de código (incluye Java, Python, C y más).
+- **Bloques de código enriquecidos** con resaltado diferenciado por lenguaje (Python, Java, C/C++ y más), numeración de líneas y etiquetas visibles.
 - **Soporte completo** para tablas, listas y citas con estilos coherentes.
 - **Salida en la misma carpeta** que el Markdown origen, con la misma ruta relativa.
 - **Environment aislado** que no interfiere con otras instalaciones Python.

--- a/asistente-asignatura/scriptsAuxiliares/conversores/markdown2Pdf/pyproject.toml
+++ b/asistente-asignatura/scriptsAuxiliares/conversores/markdown2Pdf/pyproject.toml
@@ -8,6 +8,7 @@ version = "1.0.0"
 description = "Conversor sencillo de Markdown a PDF para el proyecto teaching-agent"
 requires-python = ">=3.10"
 dependencies = [
+    "beautifulsoup4>=4.12",
     "markdown>=3.4",
     "pygments>=2.15",
     "weasyprint>=58.0",

--- a/asistente-asignatura/scriptsAuxiliares/conversores/markdown2Pdf/requirements.txt
+++ b/asistente-asignatura/scriptsAuxiliares/conversores/markdown2Pdf/requirements.txt
@@ -1,3 +1,4 @@
+beautifulsoup4>=4.12
 markdown>=3.4
 pygments>=2.15
 weasyprint>=58.0

--- a/asistente-asignatura/scriptsAuxiliares/conversores/markdown2Pdf/run_md2pdf.sh
+++ b/asistente-asignatura/scriptsAuxiliares/conversores/markdown2Pdf/run_md2pdf.sh
@@ -27,7 +27,7 @@ python - <<'PYCODE'
 try:
     import markdown  # noqa: F401
     import bs4  # noqa: F401
-    import reportlab  # noqa: F401
+    import weasyprint  # noqa: F401
     print("✅ Dependencias verificadas correctamente")
 except Exception as exc:  # pragma: no cover - ejecución manual
     print(f"❌ Error al verificar dependencias: {exc}")

--- a/asistente-asignatura/scriptsAuxiliares/conversores/markdown2Pdf/simple_converter.py
+++ b/asistente-asignatura/scriptsAuxiliares/conversores/markdown2Pdf/simple_converter.py
@@ -7,7 +7,9 @@ import argparse
 import sys
 from html import escape
 from pathlib import Path
+from typing import Iterable
 
+from bs4 import BeautifulSoup
 from markdown import markdown
 from pygments.formatters import HtmlFormatter
 from weasyprint import CSS, HTML
@@ -31,15 +33,25 @@ BASE_CSS = """
     }
 }
 
+:root {
+    --color-primary: #2563eb;
+    --color-secondary: #4b5563;
+    --color-muted: #6b7280;
+    --border-color: #d1d5db;
+    --background-soft: #f8fafc;
+    --font-base: 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+    --font-mono: 'Fira Code', 'JetBrains Mono', 'SFMono-Regular', 'Consolas', 'Menlo', monospace;
+}
+
 html {
     font-size: 12pt;
 }
 
 body {
     color: #1f2933;
-    font-family: 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+    font-family: var(--font-base);
     font-size: 1rem;
-    line-height: 1.6;
+    line-height: 1.65;
     background: #ffffff;
     string-set: doc-title attr(data-title);
 }
@@ -55,54 +67,58 @@ article.document {
 }
 
 .document__header {
-    margin-bottom: 1.2rem;
-    border-bottom: 2px solid #e5e7eb;
-    padding-bottom: 0.8rem;
+    margin-bottom: 1.5rem;
+    border-bottom: 2px solid var(--border-color);
+    padding-bottom: 1rem;
 }
 
 .document__header h1 {
-    font-size: 2.1rem;
+    font-size: 2.25rem;
     font-weight: 700;
-    color: #111827;
+    color: #0f172a;
 }
 
 h1 {
-    margin: 0 0 0.8rem 0;
-    font-size: 2.1rem;
+    margin: 0 0 1rem 0;
+    font-size: 2.25rem;
     font-weight: 700;
-    color: #111827;
+    color: #0f172a;
     letter-spacing: -0.015em;
     string-set: doc-title content();
+    page-break-after: avoid;
 }
 
 h2 {
-    margin: 1.4rem 0 0.6rem 0;
-    font-size: 1.55rem;
+    margin: 1.6rem 0 0.7rem 0;
+    font-size: 1.65rem;
     font-weight: 600;
-    color: #1f2937;
+    color: #111827;
+    page-break-after: avoid;
 }
 
 h3 {
-    margin: 1.2rem 0 0.5rem 0;
-    font-size: 1.25rem;
+    margin: 1.35rem 0 0.55rem 0;
+    font-size: 1.3rem;
     font-weight: 600;
-    color: #1f2937;
+    color: #111827;
+    page-break-after: avoid;
 }
 
 h4, h5, h6 {
-    margin: 1rem 0 0.4rem 0;
+    margin: 1.2rem 0 0.45rem 0;
     font-weight: 600;
     color: #1f2937;
+    page-break-after: avoid;
 }
 
 p {
-    margin: 0 0 0.75rem 0;
+    margin: 0 0 0.85rem 0;
     font-size: 1rem;
 }
 
 strong {
     color: #111827;
-    font-weight: 600;
+    font-weight: 650;
 }
 
 em {
@@ -110,7 +126,7 @@ em {
 }
 
 ul, ol {
-    margin: 0 0 0.75rem 1.2rem;
+    margin: 0 0 0.85rem 1.3rem;
     padding-left: 0.4rem;
 }
 
@@ -120,23 +136,24 @@ li {
 }
 
 li::marker {
-    color: #3b82f6;
+    color: var(--color-primary);
     font-weight: 600;
 }
 
 blockquote {
-    margin: 0.9rem 0;
-    padding: 0.6rem 1rem;
-    border-left: 4px solid #3b82f6;
-    background: #f8fafc;
-    color: #374151;
+    margin: 1.1rem 0;
+    padding: 0.7rem 1.1rem;
+    border-left: 4px solid var(--color-primary);
+    background: var(--background-soft);
+    color: #1f2937;
     font-style: italic;
+    box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.08);
 }
 
 code {
-    font-family: 'Fira Code', 'JetBrains Mono', 'SFMono-Regular', 'Consolas', 'Menlo', monospace;
+    font-family: var(--font-mono);
     background: #f3f4f6;
-    padding: 0.08rem 0.35rem;
+    padding: 0.08rem 0.4rem;
     border-radius: 4px;
     font-size: 0.95rem;
 }
@@ -148,18 +165,60 @@ pre code {
 }
 
 .codehilite {
-    margin: 1rem 0 1.3rem 0;
-    padding: 1rem 1.1rem;
-    border-radius: 10px;
-    border: 1px solid #d1d5db;
-    background: #f9fafb;
-    box-shadow: 0 1px 4px rgba(15, 23, 42, 0.06);
+    position: relative;
+    margin: 1.1rem 0 1.4rem 0;
+    padding: 1.2rem 1.25rem 1rem 1.25rem;
+    border-radius: 14px;
+    border: 1px solid var(--border-color);
+    background: var(--background-soft);
+    box-shadow: 0 12px 30px rgba(15, 23, 42, 0.09);
+    overflow: hidden;
+    --code-accent: #334155;
+    --code-background: #f8fafc;
+}
+
+.codehilite::before {
+    content: attr(data-language);
+    position: absolute;
+    top: 0;
+    left: 0;
+    padding: 0.45rem 0.9rem;
+    font-size: 0.7rem;
+    letter-spacing: 0.08em;
+    font-weight: 700;
+    text-transform: uppercase;
+    background: var(--code-accent);
+    color: #ffffff;
+    border-bottom-right-radius: 10px;
 }
 
 .codehilite pre {
     margin: 0;
-    overflow-wrap: normal;
     white-space: pre;
+    background: var(--code-background);
+    border-radius: 8px;
+    padding: 0.9rem 0.7rem 0.9rem 0.7rem;
+}
+
+.codehilite table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.codehilite td {
+    border: none;
+    padding: 0;
+}
+
+.codehilite .linenos {
+    padding-right: 0.9rem;
+    border-right: 1px solid rgba(148, 163, 184, 0.35);
+    color: #94a3b8;
+}
+
+.codehilite .linenos pre {
+    background: transparent;
+    padding-right: 0.75rem;
 }
 
 .codehilite::-webkit-scrollbar {
@@ -171,33 +230,74 @@ pre code {
     border-radius: 3px;
 }
 
+.codehilite.language-python,
+.codehilite[data-language="PYTHON"] {
+    --code-accent: #2563eb;
+    --code-background: #eff6ff;
+}
+
+.codehilite.language-java,
+.codehilite[data-language="JAVA"] {
+    --code-accent: #ea580c;
+    --code-background: #fff7ed;
+}
+
+.codehilite.language-c,
+.codehilite[data-language="C"] {
+    --code-accent: #059669;
+    --code-background: #ecfdf5;
+}
+
+.codehilite.language-cpp,
+.codehilite[data-language="CPP"],
+.codehilite.language-c-plus-plus {
+    --code-accent: #0ea5e9;
+    --code-background: #e0f2fe;
+}
+
+.codehilite .code-content {
+    font-family: var(--font-mono);
+    font-size: 0.94rem;
+}
+
 table {
     width: 100%;
     border-collapse: collapse;
-    margin: 1.2rem 0;
+    margin: 1.35rem 0;
     font-size: 0.97rem;
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 8px 18px rgba(15, 23, 42, 0.08);
 }
 
 th, td {
-    border: 1px solid #d1d5db;
-    padding: 0.55rem 0.75rem;
+    border: 1px solid var(--border-color);
+    padding: 0.6rem 0.85rem;
     text-align: left;
 }
 
 th {
-    background: #f3f4f6;
-    color: #111827;
-    font-weight: 600;
+    background: #eef2ff;
+    color: #1e1b4b;
+    font-weight: 650;
     text-transform: uppercase;
     letter-spacing: 0.035em;
 }
 
 tr:nth-child(even) td {
-    background: #f9fafb;
+    background: #f8fafc;
+}
+
+caption {
+    caption-side: bottom;
+    text-align: center;
+    font-size: 0.9rem;
+    color: var(--color-muted);
+    margin-top: 0.6rem;
 }
 
 a {
-    color: #2563eb;
+    color: var(--color-primary);
     text-decoration: none;
 }
 
@@ -209,42 +309,142 @@ img {
     max-width: 100%;
     display: block;
     margin: 1rem auto;
-    border-radius: 8px;
+    border-radius: 12px;
+    box-shadow: 0 12px 30px rgba(15, 23, 42, 0.12);
+}
+
+figure {
+    margin: 1.2rem auto;
+    text-align: center;
+}
+
+figcaption {
+    margin-top: 0.5rem;
+    font-size: 0.9rem;
+    color: var(--color-muted);
 }
 
 hr {
     border: none;
-    border-top: 1px solid #d1d5db;
-    margin: 1.5rem 0;
+    border-top: 1px solid var(--border-color);
+    margin: 1.75rem 0;
 }
 
 .toc {
-    border: 1px solid #d1d5db;
-    border-radius: 8px;
-    padding: 1rem;
-    background: #f9fafb;
-    margin: 1.5rem 0;
+    border: 1px solid rgba(37, 99, 235, 0.2);
+    border-radius: 12px;
+    padding: 1.2rem 1.4rem;
+    background: #eef2ff;
+    margin: 1.75rem 0;
+    box-shadow: 0 8px 22px rgba(37, 99, 235, 0.12);
 }
 
-.toc ul {
+.toc > ul {
     margin: 0.4rem 0 0 1.1rem;
 }
 
 .toc li {
     margin-bottom: 0.25rem;
 }
+
+mark {
+    background: #fef08a;
+    padding: 0.1rem 0.25rem;
+    border-radius: 4px;
+}
+
+kbd {
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    background: #e2e8f0;
+    border-radius: 6px;
+    padding: 0.15rem 0.4rem;
+    border: 1px solid rgba(148, 163, 184, 0.7);
+    box-shadow: inset 0 -2px 0 rgba(15, 23, 42, 0.1);
+}
 """
 
 
 def _build_stylesheet() -> str:
-    formatter = HtmlFormatter(style="github-light", linenos=False)
+    formatter = HtmlFormatter(
+        style="material",
+        linenos="table",
+        cssclass="codehilite",
+        wrapcode=True,
+    )
     highlight_css = formatter.get_style_defs(".codehilite")
-    # Ajustes adicionales para un contraste equilibrado.
     extra_code_css = """
-.codehilite .hll { background-color: #fef3c7; }
-.codehilite span { font-size: 0.95rem; }
+.codehilite .hll { background-color: rgba(250, 204, 21, 0.25); }
+.codehilite span { font-size: 0.94rem; }
 """
     return "\n".join([BASE_CSS.strip(), highlight_css, extra_code_css.strip()])
+
+
+def _normalise_language_name(raw_language: str | None) -> str:
+    if not raw_language:
+        return "Texto"
+
+    language = raw_language.strip().lower()
+    aliases = {
+        "py": "Python",
+        "py3": "Python",
+        "python": "Python",
+        "java": "Java",
+        "c": "C",
+        "c++": "CPP",
+        "cpp": "CPP",
+        "cxx": "CPP",
+        "sh": "Shell",
+        "bash": "Shell",
+        "json": "JSON",
+        "yaml": "YAML",
+        "yml": "YAML",
+        "txt": "Texto",
+    }
+
+    if language in aliases:
+        return aliases[language]
+
+    return language.upper()
+
+
+def _extract_language_from_classes(classes: Iterable[str]) -> str | None:
+    for class_name in classes:
+        if class_name.startswith("language-"):
+            return class_name.split("-", 1)[1]
+        if class_name in {"python", "java", "c", "cpp"}:
+            return class_name
+    return None
+
+
+def _enhance_code_blocks(html_fragment: str) -> str:
+    soup = BeautifulSoup(html_fragment, "html.parser")
+
+    for block in soup.select("div.codehilite"):
+        block_classes = list(block.get("class", []))
+        language = _extract_language_from_classes(block_classes)
+
+        if language is None:
+            code_node = block.find("code")
+            if code_node:
+                language = _extract_language_from_classes(code_node.get("class", []))
+
+        label = _normalise_language_name(language)
+        block["data-language"] = label
+
+        if language:
+            lang_class = f"language-{language.lower()}"
+            if lang_class not in block_classes:
+                block_classes.append(lang_class)
+                block["class"] = block_classes
+
+        code_content = block.find("code")
+        if code_content:
+            existing = list(code_content.get("class", []))
+            if "code-content" not in existing:
+                code_content["class"] = [*existing, "code-content"]
+
+    return str(soup)
 
 
 def _build_html_document(markdown_text: str, title: str, stylesheet: str) -> str:
@@ -256,17 +456,24 @@ def _build_html_document(markdown_text: str, title: str, stylesheet: str) -> str
             "tables",
             "toc",
             "sane_lists",
+            "attr_list",
+            "def_list",
+            "footnotes",
+            "md_in_html",
+            "admonition",
         ],
         extension_configs={
             "codehilite": {
                 "guess_lang": True,
                 "noclasses": False,
-                "pygments_style": "github-light",
-                "linenums": False,
+                "pygments_style": "material",
+                "linenums": True,
             },
             "toc": {"permalink": "#"},
         },
     )
+
+    html_body = _enhance_code_blocks(html_body)
 
     safe_title = escape(title)
     return f"""<!DOCTYPE html>
@@ -372,11 +579,20 @@ def convert_directory_markdowns(directory: Path) -> tuple[int, int]:
 
 def convert_all_markdowns() -> tuple[int, int]:
     script_dir = Path(__file__).parent
-    base_path = script_dir.parent.parent.parent / "enunciados_sinteticos"
-    if not base_path.exists():
-        print(f"Error: La ruta base {base_path} no existe")
-        return 0, 0
-    return convert_directory_markdowns(base_path)
+    candidate_roots = [
+        script_dir.parent.parent.parent / "ejercicios" / "enunciados_sinteticos",
+        script_dir.parent.parent.parent / "enunciados_sinteticos",
+    ]
+
+    for base_path in candidate_roots:
+        if base_path.exists():
+            return convert_directory_markdowns(base_path)
+
+    print(
+        "Error: No se encontró la carpeta 'enunciados_sinteticos'. "
+        "Revise la estructura del proyecto."
+    )
+    return 0, 0
 
 
 def build_parser() -> argparse.ArgumentParser:


### PR DESCRIPTION
## Summary
- refresh the PDF stylesheet with improved typography, table styling, and labelled code blocks
- annotate rendered HTML to detect languages, provide per-language highlights, and enable richer Markdown extensions
- add BeautifulSoup as a dependency, adjust dependency checks, and improve the default search path for `enunciados_sinteticos`

## Testing
- ./run_md2pdf.sh convert -f ../../../ejercicios/enunciados_sinteticos/example.md

------
https://chatgpt.com/codex/tasks/task_e_68d94f7eec748326bea19d52615071af